### PR TITLE
OpenCypher aggregate functions

### DIFF
--- a/demo/imdb/imdb_utils.py
+++ b/demo/imdb/imdb_utils.py
@@ -38,7 +38,7 @@ def populate_graph(redis_con, redis_graph):
 	# Load actors entities
 	print("Loading actors")
 	actors = {}
-	test_date = date(2017, 1, 1)
+	today = date.today()
 
 	with open(os.path.dirname(os.path.abspath(__file__)) + '/resources/actors.csv', 'r') as f:
 		reader = csv.reader(f, delimiter=',')
@@ -46,7 +46,7 @@ def populate_graph(redis_con, redis_graph):
 			name = row[0]
 			yearOfBirth = int(row[1])
 			movie = row[2]
-			age = test_date.year - yearOfBirth
+			age = today.year - yearOfBirth
 
 			if name not in actors:
 				node = Node(label="actor", properties={'name': name, 'age': age})

--- a/demo/imdb/imdb_utils.py
+++ b/demo/imdb/imdb_utils.py
@@ -38,7 +38,7 @@ def populate_graph(redis_con, redis_graph):
 	# Load actors entities
 	print("Loading actors")
 	actors = {}
-	today = date.today()
+	test_date = date(2017, 1, 1)
 
 	with open(os.path.dirname(os.path.abspath(__file__)) + '/resources/actors.csv', 'r') as f:
 		reader = csv.reader(f, delimiter=',')
@@ -46,7 +46,7 @@ def populate_graph(redis_con, redis_graph):
 			name = row[0]
 			yearOfBirth = int(row[1])
 			movie = row[2]
-			age = today.year - yearOfBirth
+			age = test_date.year - yearOfBirth
 
 			if name not in actors:
 				node = Node(label="actor", properties={'name': name, 'age': age})

--- a/src/arithmetic/agg_funcs.c
+++ b/src/arithmetic/agg_funcs.c
@@ -192,10 +192,8 @@ typedef struct {
 
 int __agg_countStep(AggCtx *ctx, SIValue *argv, int argc) {
     __agg_countCtx *ac = Agg_FuncCtx(ctx);
+    ac->count += argc;
 
-    for(int i = 0; i < argc; i ++) {
-        ac->count++;
-    }
     return AGG_OK;
 }
 

--- a/src/arithmetic/agg_funcs.c
+++ b/src/arithmetic/agg_funcs.c
@@ -218,27 +218,34 @@ typedef struct {
     double percentile;
     double *values;
     size_t count;
+    size_t values_allocated;
 } __agg_percCtx;
 
 // This function is agnostic as to percentile method
 int __agg_percStep(AggCtx *ctx, SIValue *argv, int argc) {
     __agg_percCtx *ac = Agg_FuncCtx(ctx);
 
-    // The first argument is the percentile value. This only actually needs to be set once
-    // (and is not actually used except in Reduce)
-    if (!SIValue_ToDouble(&argv[0], &ac->percentile)) {
-        return Agg_SetError(ctx,
-                "PERC_DISC Could not convert percentile argument to double");
+    // The last argument is the requested percentile, which we only
+    // need to apply on the first function invocation (at which time
+    // _agg_percCtx->percentile will be -1)
+    if (ac->percentile < 0) {
+        if (!SIValue_ToDouble(&argv[argc - 1], &ac->percentile)) {
+            return Agg_SetError(ctx,
+                    "PERC_DISC Could not convert percentile argument to double");
+        }
+        if (ac->percentile < 0 || ac->percentile > 1) {
+            return Agg_SetError(ctx,
+                    "PERC_DISC Invalid input for percentile is not a valid argument, must be a number in the range 0.0 to 1.0");
+        }
     }
 
-    // The values buffer will be resized to handle 1000 more values every time
-    // its capacity is met
-    if (ac->count + 1 % 1000 == 0) {
-        realloc(ac->values, ac->count + 1000);
+    if (ac->count + argc - 1 > ac->values_allocated) {
+        ac->values_allocated *= 2;
+        ac->values = realloc(ac->values, sizeof(double) * ac->values_allocated);
     }
 
     double n;
-    for (int i = 1; i < argc; i ++) {
+    for (int i = 0; i < argc - 1; i ++) {
         if (!SIValue_ToDouble(&argv[i], &n)) {
             if (!SIValue_IsNullPtr(&argv[i])) {
                 // not convertible to double!
@@ -272,6 +279,7 @@ AggCtx* Agg_PercDiscFunc() {
     __agg_percCtx *ac = malloc(sizeof(__agg_percCtx));
     ac->count = 0;
     ac->values = malloc(1000 * sizeof(double));
+    ac->values_allocated = 1000;
     // Percentile will be updated by the first call to Step
     ac->percentile = -1;
     return Agg_Reduce(ac, __agg_percStep, __agg_percDiscReduceNext);

--- a/src/arithmetic/agg_funcs.c
+++ b/src/arithmetic/agg_funcs.c
@@ -12,20 +12,22 @@ typedef struct {
 int __agg_sumStep(AggCtx *ctx, SIValue *argv, int argc) {
     // convert the value of the input sequence to a double if possible
     double n;
-    if (!SIValue_ToDouble(&argv[0], &n)) {
-        if (!SIValue_IsNullPtr(&argv[0])) {
-            // not convertible to double!
-            return Agg_SetError(ctx,
-                                "SUM Could not convert upstream value to double");
-        } else {
-            return AGG_OK;
+    for(int i = 0; i < argc; i ++) {
+        if (!SIValue_ToDouble(&argv[i], &n)) {
+            if (!SIValue_IsNullPtr(&argv[i])) {
+                // not convertible to double!
+                return Agg_SetError(ctx,
+                                    "SUM Could not convert upstream value to double");
+            } else {
+                return AGG_OK;
+            }
         }
-    }
-    
-    __agg_sumCtx *ac = Agg_FuncCtx(ctx);
 
-    ac->num++;
-    ac->total += n;
+        __agg_sumCtx *ac = Agg_FuncCtx(ctx);
+
+        ac->num++;
+        ac->total += n;
+    }
 
     return AGG_OK;
 }
@@ -54,20 +56,22 @@ typedef struct {
 int __agg_avgStep(AggCtx *ctx, SIValue *argv, int argc) {
     // convert the value of the input sequence to a double if possible
     double n;
-    if (!SIValue_ToDouble(&argv[0], &n)) {
-        if (!SIValue_IsNullPtr(&argv[0])) {
-            // not convertible to double!
-            return Agg_SetError(ctx,
-                                "AVG Could not convert upstream value to double");
-        } else {
-            return AGG_OK;
+    for(int i = 0; i < argc; i ++) {
+        if (!SIValue_ToDouble(&argv[i], &n)) {
+            if (!SIValue_IsNullPtr(&argv[i])) {
+                // not convertible to double!
+                return Agg_SetError(ctx,
+                                    "AVG Could not convert upstream value to double");
+            } else {
+                return AGG_OK;
+            }
         }
-    }
-    
-    __agg_avgCtx *ac = Agg_FuncCtx(ctx);
 
-    ac->count++;
-    ac->total += n;
+        __agg_avgCtx *ac = Agg_FuncCtx(ctx);
+
+        ac->count++;
+        ac->total += n;
+    }
 
     return AGG_OK;
 }
@@ -99,19 +103,21 @@ typedef struct {
 int __agg_maxStep(AggCtx *ctx, SIValue *argv, int argc) {
     // convert the value of the input sequence to a double if possible
     double n;
-    if (!SIValue_ToDouble(&argv[0], &n)) {
-        if (!SIValue_IsNullPtr(&argv[0])) {
-            // not convertible to double!
-            return Agg_SetError(ctx,
-                                "MAX Could not convert upstream value to double");
-        } else {
-            return AGG_OK;
+    for(int i = 0; i < argc; i ++) {
+        if (!SIValue_ToDouble(&argv[i], &n)) {
+            if (!SIValue_IsNullPtr(&argv[i])) {
+                // not convertible to double!
+                return Agg_SetError(ctx,
+                                    "MAX Could not convert upstream value to double");
+            } else {
+                return AGG_OK;
+            }
         }
-    }
-    
-    __agg_maxCtx *ac = Agg_FuncCtx(ctx);
-    if(n > ac->max) {
-        ac->max = n;
+
+        __agg_maxCtx *ac = Agg_FuncCtx(ctx);
+        if(n > ac->max) {
+            ac->max = n;
+        }
     }
 
     return AGG_OK;
@@ -139,19 +145,21 @@ typedef struct {
 int __agg_minStep(AggCtx *ctx, SIValue *argv, int argc) {
     // convert the value of the input sequence to a double if possible
     double n;
-    if (!SIValue_ToDouble(&argv[0], &n)) {
-        if (!SIValue_IsNullPtr(&argv[0])) {
-            // not convertible to double!
-            return Agg_SetError(ctx,
-                                "MIN Could not convert upstream value to double");
-        } else {
-            return AGG_OK;
+    for(int i = 0; i < argc; i ++) {
+        if (!SIValue_ToDouble(&argv[i], &n)) {
+            if (!SIValue_IsNullPtr(&argv[i])) {
+                // not convertible to double!
+                return Agg_SetError(ctx,
+                                    "MIN Could not convert upstream value to double");
+            } else {
+                return AGG_OK;
+            }
         }
-    }
-    
-    __agg_minCtx *ac = Agg_FuncCtx(ctx);
-    if(n < ac->min) {
-        ac->min = n;
+
+        __agg_minCtx *ac = Agg_FuncCtx(ctx);
+        if(n < ac->min) {
+            ac->min = n;
+        }
     }
 
     return AGG_OK;
@@ -177,8 +185,10 @@ typedef struct {
 } __agg_countCtx;
 
 int __agg_countStep(AggCtx *ctx, SIValue *argv, int argc) {
-    __agg_avgCtx *ac = Agg_FuncCtx(ctx);
-    ac->count++;
+    for(int i = 0; i < argc; i ++) {
+        __agg_countCtx *ac = Agg_FuncCtx(ctx);
+        ac->count++;
+    }
     return AGG_OK;
 }
 

--- a/src/arithmetic/agg_funcs.c
+++ b/src/arithmetic/agg_funcs.c
@@ -13,6 +13,8 @@ typedef struct {
 
 int __agg_sumStep(AggCtx *ctx, SIValue *argv, int argc) {
     // convert the value of the input sequence to a double if possible
+    __agg_sumCtx *ac = Agg_FuncCtx(ctx);
+
     double n;
     for(int i = 0; i < argc; i ++) {
         if (!SIValue_ToDouble(&argv[i], &n)) {
@@ -24,8 +26,6 @@ int __agg_sumStep(AggCtx *ctx, SIValue *argv, int argc) {
                 return AGG_OK;
             }
         }
-
-        __agg_sumCtx *ac = Agg_FuncCtx(ctx);
 
         ac->num++;
         ac->total += n;
@@ -57,6 +57,8 @@ typedef struct {
 
 int __agg_avgStep(AggCtx *ctx, SIValue *argv, int argc) {
     // convert the value of the input sequence to a double if possible
+    __agg_avgCtx *ac = Agg_FuncCtx(ctx);
+
     double n;
     for(int i = 0; i < argc; i ++) {
         if (!SIValue_ToDouble(&argv[i], &n)) {
@@ -69,7 +71,6 @@ int __agg_avgStep(AggCtx *ctx, SIValue *argv, int argc) {
             }
         }
 
-        __agg_avgCtx *ac = Agg_FuncCtx(ctx);
 
         ac->count++;
         ac->total += n;
@@ -80,6 +81,7 @@ int __agg_avgStep(AggCtx *ctx, SIValue *argv, int argc) {
 
 int __agg_avgReduceNext(AggCtx *ctx) {
     __agg_avgCtx *ac = Agg_FuncCtx(ctx);
+
     if(ac->count > 0) {
         Agg_SetResult(ctx, SI_DoubleVal(ac->total / ac->count));
     } else {
@@ -104,6 +106,8 @@ typedef struct {
 
 int __agg_maxStep(AggCtx *ctx, SIValue *argv, int argc) {
     // convert the value of the input sequence to a double if possible
+    __agg_maxCtx *ac = Agg_FuncCtx(ctx);
+
     double n;
     for(int i = 0; i < argc; i ++) {
         if (!SIValue_ToDouble(&argv[i], &n)) {
@@ -116,7 +120,6 @@ int __agg_maxStep(AggCtx *ctx, SIValue *argv, int argc) {
             }
         }
 
-        __agg_maxCtx *ac = Agg_FuncCtx(ctx);
         if(n > ac->max) {
             ac->max = n;
         }
@@ -146,6 +149,8 @@ typedef struct {
 
 int __agg_minStep(AggCtx *ctx, SIValue *argv, int argc) {
     // convert the value of the input sequence to a double if possible
+    __agg_minCtx *ac = Agg_FuncCtx(ctx);
+
     double n;
     for(int i = 0; i < argc; i ++) {
         if (!SIValue_ToDouble(&argv[i], &n)) {
@@ -158,7 +163,6 @@ int __agg_minStep(AggCtx *ctx, SIValue *argv, int argc) {
             }
         }
 
-        __agg_minCtx *ac = Agg_FuncCtx(ctx);
         if(n < ac->min) {
             ac->min = n;
         }
@@ -187,8 +191,9 @@ typedef struct {
 } __agg_countCtx;
 
 int __agg_countStep(AggCtx *ctx, SIValue *argv, int argc) {
+    __agg_countCtx *ac = Agg_FuncCtx(ctx);
+
     for(int i = 0; i < argc; i ++) {
-        __agg_countCtx *ac = Agg_FuncCtx(ctx);
         ac->count++;
     }
     return AGG_OK;

--- a/src/arithmetic/agg_funcs.h
+++ b/src/arithmetic/agg_funcs.h
@@ -10,6 +10,7 @@ AggCtx* Agg_AvgFunc();
 AggCtx* Agg_MaxFunc();
 AggCtx* Agg_MinFunc();
 AggCtx* Agg_CountFunc();
+AggCtx* Agg_PercDiscFunc();
 
 void Agg_RegisterFuncs();
 

--- a/src/arithmetic/arithmetic_expression.c
+++ b/src/arithmetic/arithmetic_expression.c
@@ -11,9 +11,8 @@
 static TrieMap *__aeRegisteredFuncs = NULL;
 
 SIValue AR_EXP_Evaluate(const AR_ExpNode *root) {
+
     SIValue result;
-    SIValue sub_trees[32];
-    
     /* Deal with Operation node. */
     if(root->type == AR_EXP_OP) {
         /* Aggregation function should be reduced by now. 
@@ -23,7 +22,7 @@ SIValue AR_EXP_Evaluate(const AR_ExpNode *root) {
             result = agg->result;
         } else {
             /* Evaluate each child before evaluating current node. */
-            /* TODO: deal with root->child_count > sizeof(sub_trees). */
+            SIValue sub_trees[root->op.child_count];
             for(int child_idx = 0; child_idx < root->op.child_count; child_idx++) {
                 sub_trees[child_idx] = AR_EXP_Evaluate(root->op.children[child_idx]);
             }
@@ -38,7 +37,7 @@ SIValue AR_EXP_Evaluate(const AR_ExpNode *root) {
             // Fetch entity property value.
             if (root->operand.variadic.entity_prop != NULL) {
                 SIValue *property = GraphEntity_Get_Property(*root->operand.variadic.entity, root->operand.variadic.entity_prop);
-               /* TODO: Handle PROPERTY_NOTFOUND. */
+                /* TODO: Handle PROPERTY_NOTFOUND. */
                 result = *property;
             } else {
                 result = SI_PtrVal(*root->operand.variadic.entity);
@@ -50,11 +49,11 @@ SIValue AR_EXP_Evaluate(const AR_ExpNode *root) {
 }
 
 void AR_EXP_Aggregate(const AR_ExpNode *root) {
-    SIValue sub_trees[32];
 
     if(root->type == AR_EXP_OP) {
         if(root->op.type == AR_OP_AGGREGATE) {
             /* Process child nodes before aggregating. */
+            SIValue sub_trees[root->op.child_count];
             int i = 0;
             for(; i < root->op.child_count; i++) {
                 AR_ExpNode *child = root->op.children[i];

--- a/src/arithmetic/arithmetic_expression.c
+++ b/src/arithmetic/arithmetic_expression.c
@@ -63,7 +63,7 @@ void AR_EXP_Aggregate(const AR_ExpNode *root) {
 
             /* Aggregate. */
             AggCtx *agg = root->op.agg_func;
-            agg->Step(agg, sub_trees, i+1);
+            agg->Step(agg, sub_trees, root->op.child_count);
         } else {
             /* Keep searching for aggregation nodes. */
             for(int i = 0; i < root->op.child_count; i++) {

--- a/src/util/qsort.h
+++ b/src/util/qsort.h
@@ -1,0 +1,290 @@
+/* $Id: qsort.h,v 1.5 2008-01-28 18:16:49 mjt Exp $
+ * Adopted from GNU glibc by Mjt.
+ * See stdlib/qsort.c in glibc */
+
+/* Copyright (C) 1991, 1992, 1996, 1997, 1999 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+   Written by Douglas C. Schmidt (schmidt@ics.uci.edu).
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, write to the Free
+   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+   02111-1307 USA.  */
+
+/* in-line qsort implementation.  Differs from traditional qsort() routine
+ * in that it is a macro, not a function, and instead of passing an address
+ * of a comparison routine to the function, it is possible to inline
+ * comparison routine, thus speeding up sorting a lot.
+ *
+ * Usage:
+ *  #include "iqsort.h"
+ *  #define islt(a,b) (strcmp((*a),(*b))<0)
+ *  char *arr[];
+ *  int n;
+ *  QSORT(char*, arr, n, islt);
+ *
+ * The "prototype" and 4 arguments are:
+ *  QSORT(TYPE,BASE,NELT,ISLT)
+ *  1) type of each element, TYPE,
+ *  2) address of the beginning of the array, of type TYPE*,
+ *  3) number of elements in the array, and
+ *  4) comparision routine.
+ * Array pointer and number of elements are referenced only once.
+ * This is similar to a call
+ *  qsort(BASE,NELT,sizeof(TYPE),ISLT)
+ * with the difference in last parameter.
+ * Note the islt macro/routine (it receives pointers to two elements):
+ * the only condition of interest is whenever one element is less than
+ * another, no other conditions (greather than, equal to etc) are tested.
+ * So, for example, to define integer sort, use:
+ *  #define islt(a,b) ((*a)<(*b))
+ *  QSORT(int, arr, n, islt)
+ *
+ * The macro could be used to implement a sorting function (see examples
+ * below), or to implement the sorting algorithm inline.  That is, either
+ * create a sorting function and use it whenever you want to sort something,
+ * or use QSORT() macro directly instead a call to such routine.  Note that
+ * the macro expands to quite some code (compiled size of int qsort on x86
+ * is about 700..800 bytes).
+ *
+ * Using this macro directly it isn't possible to implement traditional
+ * qsort() routine, because the macro assumes sizeof(element) == sizeof(TYPE),
+ * while qsort() allows element size to be different.
+ *
+ * Several ready-to-use examples:
+ *
+ * Sorting array of integers:
+ * void int_qsort(int *arr, unsigned n) {
+ * #define int_lt(a,b) ((*a)<(*b))
+ *   QSORT(int, arr, n, int_lt);
+ * }
+ *
+ * Sorting array of string pointers:
+ * void str_qsort(char *arr[], unsigned n) {
+ * #define str_lt(a,b) (strcmp((*a),(*b)) < 0)
+ *   QSORT(char*, arr, n, str_lt);
+ * }
+ *
+ * Sorting array of structures:
+ *
+ * struct elt {
+ *   int key;
+ *   ...
+ * };
+ * void elt_qsort(struct elt *arr, unsigned n) {
+ * #define elt_lt(a,b) ((a)->key < (b)->key)
+ *  QSORT(struct elt, arr, n, elt_lt);
+ * }
+ *
+ * And so on.
+ */
+
+/* Swap two items pointed to by A and B using temporary buffer t. */
+#define _QSORT_SWAP(a, b, t) ((void)((t = *a), (*a = *b), (*b = t)))
+
+/* Discontinue quicksort algorithm when partition gets below this size.
+   This particular magic number was chosen to work best on a Sun 4/260. */
+#define _QSORT_MAX_THRESH 4
+
+/* Stack node declarations used to store unfulfilled partition obligations
+ * (inlined in QSORT).
+typedef struct {
+  QSORT_TYPE *_lo, *_hi;
+} qsort_stack_node;
+ */
+
+/* The next 4 #defines implement a very fast in-line stack abstraction. */
+/* The stack needs log (total_elements) entries (we could even subtract
+   log(MAX_THRESH)).  Since total_elements has type unsigned, we get as
+   upper bound for log (total_elements):
+   bits per byte (CHAR_BIT) * sizeof(unsigned).
+ */
+#define _QSORT_STACK_SIZE (8 * sizeof(unsigned))
+#define _QSORT_PUSH(top, low, high)                                            \
+        (((top->_lo = (low)), (top->_hi = (high)), ++top))
+#define _QSORT_POP(low, high, top)                                             \
+        ((--top, (low = top->_lo), (high = top->_hi)))
+#define _QSORT_STACK_NOT_EMPTY (_stack < _top)
+
+
+/* Order size using quicksort.  This implementation incorporates
+   four optimizations discussed in Sedgewick:
+
+   1. Non-recursive, using an explicit stack of pointer that store the
+      next array partition to sort.  To save time, this maximum amount
+      of space required to store an array of SIZE_MAX is allocated on the
+      stack.  Assuming a 32-bit (64 bit) integer for size_t, this needs
+      only 32 * sizeof(stack_node) == 256 bytes (for 64 bit: 1024 bytes).
+      Pretty cheap, actually.
+
+   2. Chose the pivot element using a median-of-three decision tree.
+      This reduces the probability of selecting a bad pivot value and
+      eliminates certain extraneous comparisons.
+
+   3. Only quicksorts TOTAL_ELEMS / MAX_THRESH partitions, leaving
+      insertion sort to order the MAX_THRESH items within each partition.
+      This is a big win, since insertion sort is faster for small, mostly
+      sorted array segments.
+
+   4. The larger of the two sub-partitions is always pushed onto the
+      stack first, with the algorithm then concentrating on the
+      smaller partition.  This *guarantees* no more than log (total_elems)
+      stack size is needed (actually O(1) in this case)!  */
+
+/* The main code starts here... */
+#define QSORT(QSORT_TYPE,QSORT_BASE,QSORT_NELT,QSORT_LT)                       \
+{                                                                              \
+  QSORT_TYPE *const _base = (QSORT_BASE);                                      \
+  const unsigned _elems = (QSORT_NELT);                                        \
+  QSORT_TYPE _hold;                                                            \
+                                                                               \
+  /* Don't declare two variables of type QSORT_TYPE in a single                \
+   * statement: eg `TYPE a, b;', in case if TYPE is a pointer,                 \
+   * expands to `type* a, b;' wich isn't what we want.                         \
+   */                                                                          \
+                                                                               \
+  if (_elems > _QSORT_MAX_THRESH) {                                            \
+    QSORT_TYPE *_lo = _base;                                                   \
+    QSORT_TYPE *_hi = _lo + _elems - 1;                                        \
+    struct {                                                                   \
+      QSORT_TYPE *_hi; QSORT_TYPE *_lo;                                        \
+    } _stack[_QSORT_STACK_SIZE], *_top = _stack + 1;                           \
+                                                                               \
+    while (_QSORT_STACK_NOT_EMPTY) {                                           \
+      QSORT_TYPE *_left_ptr; QSORT_TYPE *_right_ptr;                           \
+                                                                               \
+      /* Select median value from among LO, MID, and HI. Rearrange             \
+         LO and HI so the three values are sorted. This lowers the             \
+         probability of picking a pathological pivot value and                 \
+         skips a comparison for both the LEFT_PTR and RIGHT_PTR in             \
+         the while loops. */                                                   \
+                                                                               \
+      QSORT_TYPE *_mid = _lo + ((_hi - _lo) >> 1);                             \
+                                                                               \
+      if (QSORT_LT (_mid, _lo))                                                \
+        _QSORT_SWAP (_mid, _lo, _hold);                                        \
+      if (QSORT_LT (_hi, _mid))        {                                       \
+        _QSORT_SWAP (_mid, _hi, _hold);                                        \
+        if (QSORT_LT (_mid, _lo))                                              \
+          _QSORT_SWAP (_mid, _lo, _hold);                                      \
+      }                                                                        \
+                                                                               \
+      _left_ptr  = _lo + 1;                                                    \
+      _right_ptr = _hi - 1;                                                    \
+                                                                               \
+      /* Here's the famous ``collapse the walls'' section of quicksort.        \
+         Gotta like those tight inner loops!  They are the main reason         \
+         that this algorithm runs much faster than others. */                  \
+      do {                                                                     \
+        while (QSORT_LT (_left_ptr, _mid))                                     \
+         ++_left_ptr;                                                          \
+                                                                               \
+        while (QSORT_LT (_mid, _right_ptr))                                    \
+          --_right_ptr;                                                        \
+                                                                               \
+        if (_left_ptr < _right_ptr) {                                          \
+          _QSORT_SWAP (_left_ptr, _right_ptr, _hold);                          \
+          if (_mid == _left_ptr)                                               \
+            _mid = _right_ptr;                                                 \
+          else if (_mid == _right_ptr)                                         \
+            _mid = _left_ptr;                                                  \
+          ++_left_ptr;                                                         \
+          --_right_ptr;                                                        \
+        }                                                                      \
+        else if (_left_ptr == _right_ptr) {                                    \
+          ++_left_ptr;                                                         \
+          --_right_ptr;                                                        \
+          break;                                                               \
+        }                                                                      \
+      } while (_left_ptr <= _right_ptr);                                       \
+                                                                               \
+     /* Set up pointers for next iteration.  First determine whether           \
+        left and right partitions are below the threshold size.  If so,        \
+        ignore one or both.  Otherwise, push the larger partition's            \
+        bounds on the stack and continue sorting the smaller one. */           \
+                                                                               \
+      if (_right_ptr - _lo <= _QSORT_MAX_THRESH) {                             \
+        if (_hi - _left_ptr <= _QSORT_MAX_THRESH)                              \
+          /* Ignore both small partitions. */                                  \
+          _QSORT_POP (_lo, _hi, _top);                                         \
+        else                                                                   \
+          /* Ignore small left partition. */                                   \
+          _lo = _left_ptr;                                                     \
+      }                                                                        \
+      else if (_hi - _left_ptr <= _QSORT_MAX_THRESH)                           \
+        /* Ignore small right partition. */                                    \
+        _hi = _right_ptr;                                                      \
+      else if (_right_ptr - _lo > _hi - _left_ptr) {                           \
+        /* Push larger left partition indices. */                              \
+        _QSORT_PUSH (_top, _lo, _right_ptr);                                   \
+        _lo = _left_ptr;                                                       \
+      }                                                                        \
+      else {                                                                   \
+        /* Push larger right partition indices. */                             \
+        _QSORT_PUSH (_top, _left_ptr, _hi);                                    \
+        _hi = _right_ptr;                                                      \
+      }                                                                        \
+    }                                                                          \
+  }                                                                            \
+                                                                               \
+  /* Once the BASE array is partially sorted by quicksort the rest             \
+     is completely sorted using insertion sort, since this is efficient        \
+     for partitions below MAX_THRESH size. BASE points to the                  \
+     beginning of the array to sort, and END_PTR points at the very            \
+     last element in the array (*not* one beyond it!). */                      \
+                                                                               \
+  {                                                                            \
+    QSORT_TYPE *const _end_ptr = _base + _elems - 1;                           \
+    QSORT_TYPE *_tmp_ptr = _base;                                              \
+    register QSORT_TYPE *_run_ptr;                                             \
+    QSORT_TYPE *_thresh;                                                       \
+                                                                               \
+    _thresh = _base + _QSORT_MAX_THRESH;                                       \
+    if (_thresh > _end_ptr)                                                    \
+      _thresh = _end_ptr;                                                      \
+                                                                               \
+    /* Find smallest element in first threshold and place it at the            \
+       array's beginning.  This is the smallest array element,                 \
+       and the operation speeds up insertion sort's inner loop. */             \
+                                                                               \
+    for (_run_ptr = _tmp_ptr + 1; _run_ptr <= _thresh; ++_run_ptr)             \
+      if (QSORT_LT (_run_ptr, _tmp_ptr))                                       \
+        _tmp_ptr = _run_ptr;                                                   \
+                                                                               \
+    if (_tmp_ptr != _base)                                                     \
+      _QSORT_SWAP (_tmp_ptr, _base, _hold);                                    \
+                                                                               \
+    /* Insertion sort, running from left-hand-side                             \
+     * up to right-hand-side.  */                                              \
+                                                                               \
+    _run_ptr = _base + 1;                                                      \
+    while (++_run_ptr <= _end_ptr) {                                           \
+      _tmp_ptr = _run_ptr - 1;                                                 \
+      while (QSORT_LT (_run_ptr, _tmp_ptr))                                    \
+        --_tmp_ptr;                                                            \
+                                                                               \
+      ++_tmp_ptr;                                                              \
+      if (_tmp_ptr != _run_ptr) {                                              \
+        QSORT_TYPE *_trav = _run_ptr + 1;                                      \
+        while (--_trav >= _run_ptr) {                                          \
+          QSORT_TYPE *_hi; QSORT_TYPE *_lo;                                    \
+          _hold = *_trav;                                                      \
+                                                                               \
+          for (_hi = _lo = _trav; --_lo >= _tmp_ptr; _hi = _lo)                \
+            *_hi = *_lo;                                                       \
+          *_hi = _hold;                                                        \
+        }                                                                      \
+      }                                                                        \
+    }                                                                          \
+  }                                                                            \
+}

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -18,6 +18,12 @@ test_agg_sum:
 	@(sh -c ./test_agg_sum)
 .PHONY: test_agg_sum
 
+argumented_aggregates: test_argumented_aggregates.o
+	$(CC) $(CFLAGS)  -o test_argumented_aggregates test_argumented_aggregates.o $(DEPS) $(LDFLAGS)
+test_argumented_aggregates:
+	@(sh -c ./test_argumented_aggregates)
+.PHONY: test_argumented_aggregates
+
 edge: test_edge.o
 	$(CC) $(CFLAGS)  -o test_edge test_edge.o  $(DEPS) $(LDFLAGS)
 test_edge:
@@ -74,6 +80,6 @@ test_arithmetic_expression:
 
 all: build test
 
-build: agg_sum edge node graph value triplet resultset_record hexastore filter_tree arithmetic_expression
+build: agg_sum edge node graph value triplet resultset_record hexastore filter_tree arithmetic_expression argumented_aggregates
 
-test: test_agg_sum test_edge test_node test_graph test_value test_triplet test_resultset_record test_hexastore test_filter_tree test_arithmetic_expression
+test: test_agg_sum test_edge test_node test_graph test_value test_triplet test_resultset_record test_hexastore test_filter_tree test_arithmetic_expression test_argumented_aggregates

--- a/tests/unit/test_argumented_aggregates.c
+++ b/tests/unit/test_argumented_aggregates.c
@@ -42,6 +42,8 @@ void test_percentile_disc() {
         AR_EXP_Reduce(perc);
         _test_ar_func(perc, AR_EXP_Evaluate(expected[i]));
     }
+    AR_EXP_Free(perc);
+
     printf("test_percentile_disc - PASS!\n");
 }
 

--- a/tests/unit/test_argumented_aggregates.c
+++ b/tests/unit/test_argumented_aggregates.c
@@ -21,28 +21,26 @@ void test_percentile_disc() {
     AR_ExpNode *half = AR_EXP_NewConstOperandNode(SI_DoubleVal(0.5));
     AR_ExpNode *one = AR_EXP_NewConstOperandNode(SI_DoubleVal(1));
 
-    AR_ExpNode *children[6];
-    for (int i = 1; i <= 5; i ++) {
-        children[i - 1] = AR_EXP_NewConstOperandNode(SI_DoubleVal(i * 2));
-    }
-
     AR_ExpNode *test_percentiles[5] = {zero, dot_one, one_third, half, one};
     // percentile_disc should always return a value actually contained in the set
-    AR_ExpNode *expected[5] = {children[0], children[0],
-        children[1], children[2], children[4]};
+    int expected[5] = {0, 0, 1, 2, 4};
+    /* AR_ExpNode *expected[5] = {children[0], children[0], */
+        /* children[1], children[2], children[4]}; */
 
     AR_ExpNode *perc;
     for (int i = 0; i < 5; i ++) {
         perc = AR_EXP_NewOpNode("percentileDisc", 6);
-        memcpy(perc->op.children, children, 5 * sizeof(AR_ExpNode*));
+        for (int j = 1; j <= 5; j ++) {
+            perc->op.children[j - 1] = AR_EXP_NewConstOperandNode(SI_DoubleVal(j * 2));
+        }
         // The last child of this node will be the requested percentile
         perc->op.children[5] = test_percentiles[i];
         AR_EXP_Aggregate(perc);
         // Reduce sorts the list and applies the percentile formula
         AR_EXP_Reduce(perc);
-        _test_ar_func(perc, AR_EXP_Evaluate(expected[i]));
+        _test_ar_func(perc, AR_EXP_Evaluate(perc->op.children[expected[i]]));
+        AR_EXP_Free(perc);
     }
-    AR_EXP_Free(perc);
 
     printf("test_percentile_disc - PASS!\n");
 }

--- a/tests/unit/test_argumented_aggregates.c
+++ b/tests/unit/test_argumented_aggregates.c
@@ -21,23 +21,22 @@ void test_percentile_disc() {
     AR_ExpNode *half = AR_EXP_NewConstOperandNode(SI_DoubleVal(0.5));
     AR_ExpNode *one = AR_EXP_NewConstOperandNode(SI_DoubleVal(1));
 
-    AR_ExpNode *perc = AR_EXP_NewOpNode("PERC_D", 6);
+    AR_ExpNode *children[6];
     for (int i = 1; i <= 5; i ++) {
-        perc->op.children[i] = AR_EXP_NewConstOperandNode(SI_DoubleVal(i * 2));
+        children[i - 1] = AR_EXP_NewConstOperandNode(SI_DoubleVal(i * 2));
     }
 
     AR_ExpNode *test_percentiles[5] = {zero, dot_one, one_third, half, one};
     // percentile_disc should always return a value actually contained in the set
-    AR_ExpNode *expected[5] = {perc->op.children[1], perc->op.children[1],
-        perc->op.children[3], perc->op.children[5], perc->op.children[2]};
+    AR_ExpNode *expected[5] = {children[0], children[0],
+        children[1], children[2], children[4]};
 
+    AR_ExpNode *perc;
     for (int i = 0; i < 5; i ++) {
-        // The first child of this node will be the requested percentile
-        perc->op.children[0] = test_percentiles[i];
-        // Aggregate sets the desired percentile value and adds each child to the list
-        // TODO as such, every iteration of this loop will add all the values again,
-        // which does not affect the calculation result (because percentiles) but still
-        // makes this a kinda weird way to test
+        perc = AR_EXP_NewOpNode("percentileDisc", 6);
+        memcpy(perc->op.children, children, 5 * sizeof(AR_ExpNode*));
+        // The last child of this node will be the requested percentile
+        perc->op.children[5] = test_percentiles[i];
         AR_EXP_Aggregate(perc);
         // Reduce sorts the list and applies the percentile formula
         AR_EXP_Reduce(perc);

--- a/tests/unit/test_argumented_aggregates.c
+++ b/tests/unit/test_argumented_aggregates.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
-#include "../../src/arithmetic/arithmetic_expression.h"
 #include "assert.h"
+#include "../../src/arithmetic/arithmetic_expression.h"
+#include "../../src/arithmetic/agg_funcs.h"
 
 void _test_ar_func(AR_ExpNode *root, SIValue expected) {
     SIValue res = AR_EXP_Evaluate(root);
@@ -16,16 +17,16 @@ void test_percentile_disc() {
     // Percentiles to check
     AR_ExpNode *zero = AR_EXP_NewConstOperandNode(SI_DoubleVal(0));
     AR_ExpNode *dot_one = AR_EXP_NewConstOperandNode(SI_DoubleVal(0.1));
+    AR_ExpNode *one_third = AR_EXP_NewConstOperandNode(SI_DoubleVal(0.33));
     AR_ExpNode *half = AR_EXP_NewConstOperandNode(SI_DoubleVal(0.5));
     AR_ExpNode *one = AR_EXP_NewConstOperandNode(SI_DoubleVal(1));
-    AR_ExpNode *one_third = AR_EXP_NewConstOperandNode(SI_DoubleVal(0.33));
 
     AR_ExpNode *perc = AR_EXP_NewOpNode("PERC_D", 6);
     for (int i = 1; i <= 5; i ++) {
         perc->op.children[i] = AR_EXP_NewConstOperandNode(SI_DoubleVal(i * 2));
     }
 
-    AR_ExpNode *test_percentiles[5] = {zero, dot_one, half, one, one_third};
+    AR_ExpNode *test_percentiles[5] = {zero, dot_one, one_third, half, one};
     // percentile_disc should always return a value actually contained in the set
     AR_ExpNode *expected[5] = {perc->op.children[1], perc->op.children[1],
         perc->op.children[3], perc->op.children[5], perc->op.children[2]};
@@ -44,6 +45,7 @@ void test_percentile_disc() {
     }
     printf("test_percentile_disc - PASS!\n");
 }
+
 int main(int argc, char **argv) {
     AR_RegisterFuncs();
     Agg_RegisterFuncs();

--- a/tests/unit/test_argumented_aggregates.c
+++ b/tests/unit/test_argumented_aggregates.c
@@ -1,0 +1,54 @@
+#include <stdio.h>
+#include "../../src/arithmetic/arithmetic_expression.h"
+#include "assert.h"
+
+void _test_ar_func(AR_ExpNode *root, SIValue expected) {
+    SIValue res = AR_EXP_Evaluate(root);
+
+    if(res.doubleval != expected.doubleval) {
+        printf("res.doubleval: %lf expected.doubleval: %lf\n", res.doubleval, expected.doubleval);
+    }
+
+    assert(res.doubleval == expected.doubleval);
+}
+
+void test_percentile_disc() {
+    // Percentiles to check
+    AR_ExpNode *zero = AR_EXP_NewConstOperandNode(SI_DoubleVal(0));
+    AR_ExpNode *dot_one = AR_EXP_NewConstOperandNode(SI_DoubleVal(0.1));
+    AR_ExpNode *half = AR_EXP_NewConstOperandNode(SI_DoubleVal(0.5));
+    AR_ExpNode *one = AR_EXP_NewConstOperandNode(SI_DoubleVal(1));
+    AR_ExpNode *one_third = AR_EXP_NewConstOperandNode(SI_DoubleVal(0.33));
+
+    AR_ExpNode *perc = AR_EXP_NewOpNode("PERC_D", 6);
+    for (int i = 1; i <= 5; i ++) {
+        perc->op.children[i] = AR_EXP_NewConstOperandNode(SI_DoubleVal(i * 2));
+    }
+
+    AR_ExpNode *test_percentiles[5] = {zero, dot_one, half, one, one_third};
+    // percentile_disc should always return a value actually contained in the set
+    AR_ExpNode *expected[5] = {perc->op.children[1], perc->op.children[1],
+        perc->op.children[3], perc->op.children[5], perc->op.children[2]};
+
+    for (int i = 0; i < 5; i ++) {
+        // The first child of this node will be the requested percentile
+        perc->op.children[0] = test_percentiles[i];
+        // Aggregate sets the desired percentile value and adds each child to the list
+        // TODO as such, every iteration of this loop will add all the values again,
+        // which does not affect the calculation result (because percentiles) but still
+        // makes this a kinda weird way to test
+        AR_EXP_Aggregate(perc);
+        // Reduce sorts the list and applies the percentile formula
+        AR_EXP_Reduce(perc);
+        _test_ar_func(perc, AR_EXP_Evaluate(expected[i]));
+    }
+    printf("test_percentile_disc - PASS!\n");
+}
+int main(int argc, char **argv) {
+    AR_RegisterFuncs();
+    Agg_RegisterFuncs();
+
+    test_percentile_disc();
+
+    return 0;
+}


### PR DESCRIPTION
This branch implements the PercentileDisc function as described by Neo4J, as well as some minor alterations that seemed prudent along the way.

It is by no means finished, but I thought this would be the most convenient way to discuss the work - let me know if a different medium is preferred!

The sorting and actual math appear to work fine both within unit tests and when invoked from Redis. The Redis command itself accepts an arbitrary tree or number of constants as arguments, followed by a double between 0 and 1 that represents the percentile the user is interested in.

The most glaring issue right now is the hard-coded allocation at `agg_funcs.c:273`, which is decidedly temporary. I believe that we should have access to the count of values by the time this allocation is necessary, but am not sure how to retrieve that number.

I am also storing the user-requested percentile value in the `__agg_percStep` function, as I did not want to deviate from the initializer typedef, but this is a bit wasteful.

Auxiliary memory (`value_count * sizeof(double)) is being used in the `__agg_percCtx` to allow the ordering of the set; there are likely better options. Additionally, I have not yet added any code to free this memory.

It is likely that I misapplied this design, so please let me know how I can improve this addition!