### PR TITLE
Index create operations

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -5,7 +5,7 @@ CC=gcc
 export CC
 
 # if DEBUG env var is set, we compile with "debug" cflags
-DEBUGFLAGS = -g -ggdb -O3 
+DEBUGFLAGS = -g -ggdb -O3
 ifeq ($(DEBUG), 1)
 	DEBUGFLAGS = -g -ggdb3 -O0
 endif
@@ -45,6 +45,7 @@ CC_SOURCES += $(wildcard $(SOURCEDIR)/resultset/*.c)
 CC_SOURCES += $(wildcard $(SOURCEDIR)/stores/*.c)
 CC_SOURCES += $(wildcard $(SOURCEDIR)/util/*.c)
 CC_SOURCES += $(wildcard $(SOURCEDIR)/dep/rax/*.c)
+CC_SOURCES += $(wildcard $(SOURCEDIR)/index/*.c)
 
 # Convert all sources to .o files
 CC_OBJECTS = $(patsubst %.c, %.o, $(CC_SOURCES) )

--- a/src/index/index.c
+++ b/src/index/index.c
@@ -1,0 +1,141 @@
+#include "index.h"
+
+int compareNodes(const void *a, const void *b) {
+  return ((Node*)a)->id - ((Node*)b)->id;
+}
+
+int compareStrings(void *a, void *b, void *ctx) {
+  return strcmp(((SIValue*)a)->stringval, ((SIValue*)b)->stringval);
+}
+
+// TODO this seems inefficient
+int compareNumerics(void *p1, void *p2, void *ctx) {
+  double a, b;
+  SIValue_ToDouble(p1, &a);
+  SIValue_ToDouble(p2, &b);
+  return a - b;
+}
+
+/*
+ * The index must maintain its own copy of the indexed SIValue
+ * so that it becomes outdated but not broken by updates to the property.
+ */
+void cloneKey(void **property) {
+  SIValue *redirect = *property;
+  *redirect = SI_Clone(*redirect);
+}
+
+void freeKey(void *key) {
+  SIValue_Free(key);
+}
+
+// Create and populate index for specified property
+// (This function will create separate string and numeric indices if property has mixed types)
+void indexProperty(RedisModuleCtx *ctx, const char *graphName, AST_IndexNode *indexOp) {
+  const char *index_label = indexOp->target.label;
+  const char *index_prop = indexOp->target.property;
+  LabelStore *store = LabelStore_Get(ctx, STORE_NODE, graphName, index_label);
+
+  LabelStoreIterator it;
+  LabelStore_Scan(store, &it);
+
+  char *nodeId;
+  uint16_t nodeIdLen;
+  Node *node;
+  EntityProperty *prop;
+
+  // We maintain one index per property per type;
+  // these will be created as necessary
+  Index *numeric_index = NULL;
+  Index *string_index = NULL;
+
+  // In the most common case, the node currently being indexed will be placed in the same index as the
+  // previous node, so we will try to optimize for that scenario
+  SIType last_key_type = T_NULL;
+  Index *current_index = NULL;
+
+  int i;
+  int prop_index = 0;
+  while(LabelStoreIterator_Next(&it, &nodeId, &nodeIdLen, (void**)&node)) {
+    // If the sought property is at a different offset than it occupied in the previous node,
+    // then seek and update
+    if (strcmp(index_prop, node->properties[prop_index].name)) {
+      for (i = 0; i < node->prop_count; i ++) {
+        prop = node->properties + i;
+        if (!strcmp(index_prop, prop->name)) {
+          prop_index = i;
+          break;
+        }
+      }
+    }
+    prop = node->properties + prop_index;
+    // This value will be cloned within the skiplistInsert routine if necessary
+    SIValue *key = &prop->value;
+
+    if (key->type ^ last_key_type) {
+      // The current property is of a different type than the last,
+      // or we have not yet constructed an index
+      last_key_type = key->type;
+      if (key->type == T_STRING) {
+        if (string_index == NULL) {
+          // This is the first string property for this label; make a new index
+          string_index = createIndex(index_label, index_prop, T_STRING);
+          Vector_Push(tmp_index_store, string_index);
+        }
+        current_index = string_index;
+      } else if (key->type & SI_NUMERIC) {
+        if (numeric_index == NULL) {
+          // This is the first numeric property for this label; make a new index
+          numeric_index = createIndex(index_label, index_prop, SI_NUMERIC);
+          Vector_Push(tmp_index_store, numeric_index);
+        }
+        current_index = numeric_index;
+      } else {
+        // This property was neither a string nor numeric value.
+        // TODO I don't think that this scenario should be possible, but if we reach this
+        // point we will currently just skip this node
+        last_key_type = T_NULL;
+        continue;
+      }
+    }
+
+    skiplistInsert(current_index->sl, key, node);
+  }
+}
+
+Index* createIndex(const char *label, const char *property, SIType value_type) {
+  Index *index = malloc(sizeof(Index));
+  index->target.label = strdup(label);
+  index->target.property = strdup(property);
+  index->value_type = value_type;
+
+  if (value_type == T_STRING) {
+    index->sl = skiplistCreate(compareStrings, NULL, compareNodes, cloneKey, freeKey);
+  } else {
+    index->sl = skiplistCreate(compareNumerics, NULL, compareNodes, cloneKey, freeKey);
+  }
+
+  return index;
+}
+
+Index* findIndex(const char *label, Vector *properties) {
+  if (!tmp_index_store) return NULL;
+
+  Index *index_to_check;
+  const char *cur_prop;
+  for (int i = 0; i < Vector_Size(tmp_index_store); i ++) {
+    Vector_Get(tmp_index_store, i, &index_to_check);
+    if (strcmp(index_to_check->target.label, label)) continue;
+
+    for (int j = 0; j < Vector_Size(properties); j ++) {
+      Vector_Get(properties, j, &cur_prop);
+
+      // TODO We are not yet assessing which viable index would
+      // be best to use.
+      if (!strcmp(index_to_check->target.property, cur_prop)) {
+        return index_to_check;
+      }
+    }
+  }
+  return NULL;
+}

--- a/src/index/index.h
+++ b/src/index/index.h
@@ -1,0 +1,29 @@
+#ifndef __INDEX_H__
+#define __INDEX_H__
+
+#include "../redismodule.h"
+#include "../graph/graph_entity.h"
+#include "../stores/store.h"
+#include "../util/skiplist.h"
+#include "../parser/ast.h"
+#include "../graph/node.h"
+#include "../dep/rax/rax.h"
+
+/*
+ * TODO at time of index creation, graph does not exist.
+ * Where to store indices? I lean towards external structure -
+ * mock it up with a global vector for the moment
+ */
+Vector *tmp_index_store;
+
+typedef struct {
+  IndexTarget target;
+  skiplist *sl;
+  SIType value_type;
+} Index;
+
+Index* createIndex(const char *label, const char *property, SIType value_type);
+void indexProperty(RedisModuleCtx *ctx, const char *graphName, AST_IndexNode *indexOp);
+Index* findIndex(const char *label, Vector *properties);
+
+#endif

--- a/src/index/index_type.c
+++ b/src/index/index_type.c
@@ -1,0 +1,147 @@
+#include "index_type.h"
+
+/* declaration of the type for redis registration. */
+RedisModuleType *IndexRedisModuleType;
+
+void *IndexType_RdbLoad(RedisModuleIO *rdb, int encver) {
+  if (encver != 0) {
+    return NULL;
+  }
+
+  const char *label = RedisModule_LoadStringBuffer(rdb, NULL);
+  const char *property = RedisModule_LoadStringBuffer(rdb, NULL);
+  SIType value_type = RedisModule_LoadUnsigned(rdb);
+  Index *index = createIndex(label, property, value_type);
+
+  loadSkiplist(rdb, index->sl);
+
+  return index;
+}
+
+void IndexType_RdbSave(RedisModuleIO *rdb, void *value) {
+  Index *index = value;
+
+  serializeIndex(rdb, index);
+}
+
+void IndexType_AofRewrite(RedisModuleIO *aof, RedisModuleString *key, void *value) {
+  // TODO: implement.
+}
+
+void IndexType_Free(void *value) {
+  Index *index = value;
+  // free
+}
+
+int IndexType_Register(RedisModuleCtx *ctx) {
+  RedisModuleTypeMethods tm = {.version = REDISMODULE_TYPE_METHOD_VERSION,
+    .rdb_load = IndexType_RdbLoad,
+    .rdb_save = IndexType_RdbSave,
+    .aof_rewrite = IndexType_AofRewrite,
+    .free = IndexType_Free};
+
+  IndexRedisModuleType = RedisModule_CreateDataType(ctx, "indextype", INDEX_TYPE_ENCODING_VERSION, &tm);
+
+  if (IndexRedisModuleType == NULL) {
+    return REDISMODULE_ERR;
+  }
+  return REDISMODULE_OK;
+}
+
+void saveSIValue(RedisModuleIO *rdb, SIValue *v) {
+  // Elem 1: key type
+  RedisModule_SaveUnsigned(rdb, v->type);
+
+  // Elem 2: key val
+  if (v->type == T_STRING) {
+      RedisModule_SaveStringBuffer(rdb, v->stringval, strlen(v->stringval) + 1);
+  } else if (v->type && SI_NUMERIC) {
+    RedisModule_SaveDouble(rdb, v->doubleval);
+    /*
+       TODO we compare numeric keys exclusively as doubles -
+       verify that this assumption is valid. Else, something like below routine?
+       RedisModule_* functions always operate on 64-bit values
+    */
+    /*
+    double converted;
+    if (SIValue_To_Double(v, &converted)) {
+      RedisModule_SaveDouble(rdb, converted);
+    } else {
+      // Conversion to double failed
+    }
+    */
+  }
+}
+
+SIValue loadSIValue(RedisModuleIO *rdb) {
+  // Elem 1: key type
+  SIValue v;
+  // TODO assumes 64 bit
+  v.type = RedisModule_LoadUnsigned(rdb);
+
+  // Elem 2: key val
+  if (v.type == T_STRING) {
+    // TODO safe?
+    v.stringval = RedisModule_LoadStringBuffer(rdb, NULL);
+  } else {
+    v.doubleval = RedisModule_LoadDouble(rdb);
+  }
+
+  return v;
+}
+
+void serializeSkiplistNode(RedisModuleIO *rdb, skiplistNode *sl_node) {
+  // Elem 1: SIValue key
+  saveSIValue(rdb, sl_node->key);
+
+  // Elem 2: value (Node) count
+  RedisModule_SaveUnsigned(rdb, (uint64_t)sl_node->numVals);
+
+  // Elem 3-x: buffer of Node IDs
+  Node *graph_node;
+
+  for (int i = 0; i < sl_node->numVals; i ++) {
+    graph_node = sl_node->vals[i];
+    // graph_node->id is of type `long int`
+    RedisModule_SaveSigned(rdb, (int64_t)graph_node->id);
+  }
+}
+
+void serializeSkiplist(RedisModuleIO *rdb, skiplist *sl) {
+  // Elem: skiplist length
+  RedisModule_SaveUnsigned(rdb, (uint64_t)sl->length);
+
+  skiplistNode *node = sl->header->level[0].forward;
+  while (node) {
+    // Need to serialize key-val pairs; levels don't matter (and should in fact be restructured on skiplist load)
+    serializeSkiplistNode(rdb, node);
+    // Could free each node at this point
+    node = node->level[0].forward;
+  }
+}
+
+void serializeIndex(RedisModuleIO *rdb, Index *index) {
+  RedisModule_SaveStringBuffer(rdb, index->target.label, strlen(index->target.label) + 1);
+  RedisModule_SaveStringBuffer(rdb, index->target.property, strlen(index->target.property) + 1);
+  RedisModule_SaveUnsigned(rdb, index->value_type);
+
+  serializeSkiplist(rdb, index->sl);
+}
+
+void loadSkiplist(RedisModuleIO *rdb, skiplist *sl) {
+  uint64_t sl_len = RedisModule_LoadUnsigned(rdb);
+  uint64_t node_num_vals;
+
+  for (int i = 0; i < sl_len; i ++) {
+    // Loop over key-val pairs
+    SIValue key = loadSIValue(rdb);
+
+    node_num_vals = RedisModule_LoadUnsigned(rdb);
+    for (int j = 0; j < node_num_vals; j ++) {
+      int64_t node_id = RedisModule_LoadSigned(rdb);
+      // associate with Node*?
+      printf("ID: %ld\n", node_id);
+      // skiplistInsert(sl, key, node);
+    }
+  }
+}

--- a/src/index/index_type.h
+++ b/src/index/index_type.h
@@ -1,0 +1,26 @@
+#ifndef __INDEX_TYPE_H__
+#define __INDEX_TYPE_H__
+
+#include "index.h"
+#include "../redismodule.h"
+
+extern RedisModuleType *IndexRedisModuleType;
+
+#define INDEX_TYPE_ENCODING_VERSION 1
+
+int IndexType_Register(RedisModuleCtx *ctx);
+void* IndexType_RdbLoad(RedisModuleIO *rdb, int encver);
+void IndexType_RdbSave(RedisModuleIO *rdb, void *value);
+void IndexType_AofRewrite(RedisModuleIO *aof, RedisModuleString *key, void *value);
+void IndexType_Free(void *value);
+
+SIValue loadSIValue(RedisModuleIO *rdb);
+void loadSkiplist(RedisModuleIO *rdb, skiplist *sl);
+void saveSIValue(RedisModuleIO *rdb, SIValue *val);
+
+void serializeIndex(RedisModuleIO *rdb, Index *index);
+void serializeSkiplist(RedisModuleIO *rdb, skiplist *sl);
+void serializeSkiplistNode(RedisModuleIO *rdb, skiplistNode *sl_node);
+
+#endif
+

--- a/src/module.c
+++ b/src/module.c
@@ -37,6 +37,7 @@
 #include "execution_plan/execution_plan.h"
 
 #include "index/index.h"
+#include "index/index_type.h"
 
 AST_Query* _parse_query(RedisModuleCtx *ctx, const char *query, const char *graphName, char **errMsg) {
     AST_Query* ast;
@@ -257,6 +258,11 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
 
     if(RaxType_Register(ctx) == REDISMODULE_ERR) {
         printf("Failed to register raxtype\n");
+        return REDISMODULE_ERR;
+    }
+
+    if(IndexType_Register(ctx) == REDISMODULE_ERR) {
+        printf("Failed to register indextype\n");
         return REDISMODULE_ERR;
     }
 


### PR DESCRIPTION
This PR includes functions for creating and populating indices in 'src/index/index.c'.

Multiple indices are constructed for mixed-type properties, and the skiplist comparator functions have been simplified considerably.

'src/index/index_type.c' introduces the functions required to persist indices, but I doubt that they will work as intended currently. This file is modeled after 'trie_types.c' (which has now been replaced with the Rax files).

'src/module.c' has been updated to address the concerns you raised in PR #98 , so CREATE/DROP INDEX queries and traditional queries that build out an ExecutionPlan should be separated by more sensibly organized conditionals.