### PR TITLE
Deleted include of non-existent file path

### DIFF
--- a/tests/unit/test_skiplist_graph.c
+++ b/tests/unit/test_skiplist_graph.c
@@ -4,7 +4,6 @@
 #include "../../src/util/skiplist.h"
 #include "../../src/value.h"
 #include "../../src/graph/node.h"
-#include "../../src/index/index.h"
 
 char *words[] = {"foo",  "bar",     "zap",    "pomo",
                  "pera", "arancio", "limone", NULL};


### PR DESCRIPTION
Sorry, this was an oversight on my part! This commit fixes a compilation error when running `make test` after the merge of PR #107  